### PR TITLE
fix(telegram): enable spoiler formatting (||text||)

### DIFF
--- a/src/telegram/format.test.ts
+++ b/src/telegram/format.test.ts
@@ -68,4 +68,14 @@ describe("markdownToTelegramHtml", () => {
     const res = markdownToTelegramHtml("[**bold**](https://example.com)");
     expect(res).toBe('<a href="https://example.com"><b>bold</b></a>');
   });
+
+  it("renders spoiler markers as tg-spoiler tags", () => {
+    const res = markdownToTelegramHtml("||secret||");
+    expect(res).toBe("<tg-spoiler>secret</tg-spoiler>");
+  });
+
+  it("renders spoiler with nested formatting", () => {
+    const res = markdownToTelegramHtml("||**secret** text||");
+    expect(res).toBe("<tg-spoiler><b>secret</b> text</tg-spoiler>");
+  });
 });

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -45,6 +45,7 @@ function renderTelegramHtml(ir: MarkdownIR): string {
       strikethrough: { open: "<s>", close: "</s>" },
       code: { open: "<code>", close: "</code>" },
       code_block: { open: "<pre><code>", close: "</code></pre>" },
+      spoiler: { open: "<tg-spoiler>", close: "</tg-spoiler>" },
     },
     escapeText: escapeHtml,
     buildLink: buildTelegramLink,
@@ -57,6 +58,7 @@ export function markdownToTelegramHtml(
 ): string {
   const ir = markdownToIR(markdown ?? "", {
     linkify: true,
+    enableSpoilers: true,
     headingStyle: "none",
     blockquotePrefix: "",
     tableMode: options.tableMode,
@@ -82,6 +84,7 @@ export function markdownToTelegramChunks(
 ): TelegramFormattedChunk[] {
   const ir = markdownToIR(markdown ?? "", {
     linkify: true,
+    enableSpoilers: true,
     headingStyle: "none",
     blockquotePrefix: "",
     tableMode: options.tableMode,


### PR DESCRIPTION
## Summary

Fixes #1 — Telegram spoiler markers (`||text||`) were not rendering as `<tg-spoiler>` tags.

## Changes

1. Added `spoiler` to `styleMarkers` in `renderTelegramHtml()`
2. Added `enableSpoilers: true` to `markdownToIR()` calls in both `markdownToTelegramHtml()` and `markdownToTelegramChunks()`
3. Added tests for spoiler rendering

## Before

```
Input: ||secret||
Output: secret (plain text)
```

## After

```
Input: ||secret||
Output: <tg-spoiler>secret</tg-spoiler>
```